### PR TITLE
fix: make 'remote' compile again

### DIFF
--- a/remote/CMakeLists.txt
+++ b/remote/CMakeLists.txt
@@ -1,13 +1,13 @@
 cmake_minimum_required(VERSION 3.20)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+set(CMAKE_CXX_COMPILER g++-14)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-include(${CMAKE_CURRENT_LIST_DIR}/../cmake/CPM.cmake)
+add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/../core _deps/zfsutils_core)
 
 project(zfsutils_remote CXX)
-
-add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/../core _deps/zfsutils_core)
 
 list(PREPEND CMAKE_PREFIX_PATH "$ENV{HOME}/.local")
 find_package(Protobuf CONFIG REQUIRED)

--- a/remote/inc/zfsutils/remote/pool.hpp
+++ b/remote/inc/zfsutils/remote/pool.hpp
@@ -1,10 +1,14 @@
 #pragma once
 
-#include "remotezfs.grpc.pb.h"
-#include "remotezfs.pb.h"
 #include "zfsutils/interface/dataset.hpp"
 #include "zfsutils/interface/pool.hpp"
+
+#pragma push_macro("verify")
+#undef verify
+#include "remotezfs.grpc.pb.h"
+#include "remotezfs.pb.h"
 #include <grpcpp/grpcpp.h>
+#pragma pop_macro("verify")
 
 namespace zfsutils {
 namespace remote {

--- a/remote/test/test_pool_info.cpp
+++ b/remote/test/test_pool_info.cpp
@@ -42,17 +42,22 @@ int main() {
         datasetClient.ListDatasets(pool);
     }
 
-    zfsutils::Pool myPool = zfsutils::Pool::open("testpool");
-    std::shared_ptr<zfsutils::Pool> myPoolShared =
-        std::make_shared<zfsutils::Pool>(std::move(myPool));
-    std::vector<std::shared_ptr<zfsutils::interface::IPool>> mixedPools{};
-    mixedPools.push_back(myPoolShared);
-    std::shared_ptr<RemotePool> myRemotePoolShared =
-        std::make_shared<RemotePool>(std::move(remotePools[0]));
-    mixedPools.push_back(myRemotePoolShared);
+    try {
+        zfsutils::Pool myPool = zfsutils::Pool::open("testpool");
+        std::shared_ptr<zfsutils::Pool> myPoolShared =
+            std::make_shared<zfsutils::Pool>(std::move(myPool));
+        std::vector<std::shared_ptr<zfsutils::interface::IPool>> mixedPools{};
+        mixedPools.push_back(myPoolShared);
+        std::shared_ptr<RemotePool> myRemotePoolShared =
+            std::make_shared<RemotePool>(std::move(remotePools[0]));
+        mixedPools.push_back(myRemotePoolShared);
 
-    std::cout << "name: " << mixedPools[0]->name() << std::endl;
-    for (std::shared_ptr<zfsutils::interface::IPool> pool : mixedPools) {
-        pool->printPoolInfo();
+        std::cout << "name: " << mixedPools[0]->name() << std::endl;
+        for (std::shared_ptr<zfsutils::interface::IPool> pool : mixedPools) {
+            pool->printPoolInfo();
+        }
+    } catch (std::exception &e) {
+        std::cerr << e.what() << std::endl;
+        return 1;
     }
 }

--- a/remote/test/test_pool_info.cpp
+++ b/remote/test/test_pool_info.cpp
@@ -3,14 +3,17 @@
 //
 #include <iostream>
 
-#include "pool.grpc.pb.h"
-#include "pool.pb.h"
-#include <grpcpp/grpcpp.h>
-
 #include "zfsutils/pool.hpp"
 
 #include "zfsutils/interface/pool.hpp"
 #include "zfsutils/remote/pool.hpp"
+
+#pragma push_macro("verify")
+#undef verify
+#include "remotezfs.grpc.pb.h"
+#include "remotezfs.pb.h"
+#include <grpcpp/grpcpp.h>
+#pragma pop_macro("verify")
 
 int main() {
     using namespace zfsutils::remote;

--- a/remote/test/test_pool_info_server.cpp
+++ b/remote/test/test_pool_info_server.cpp
@@ -3,10 +3,13 @@
 
 #include "zfsutils/pool.hpp"
 
+#pragma push_macro("verify")
+#undef verify
 #include <grpcpp/grpcpp.h>
 
 #include "remotezfs.grpc.pb.h"
 #include "remotezfs.pb.h"
+#pragma pop_macro("verify")
 
 class RemotePoolService final : public remotezfs::RemotePool::Service {
     grpc::Status ListPools(grpc::ServerContext *context,


### PR DESCRIPTION
I've had several issues with ZFS's `verify` macro

In the end a reasonable workaround is this:
```c++
#pragma push_macro("verify")
#undef verify
#include <grpcpp/grpcpp.h>
#include ${various_other_grpc_stuff}
#pragma pop_macro("verify")
```